### PR TITLE
Wrapper for np.select() and np.where()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kwanmath"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="kwan3217", email="kwan3217@gmail.com" },
 ]

--- a/src/kwanmath/vector.py
+++ b/src/kwanmath/vector.py
@@ -1,3 +1,5 @@
+from numbers import Number
+
 import numpy as np
 
 def vindex(v):
@@ -254,4 +256,46 @@ def vv(sv):
     :return: Position part, will be stack matching sv
     """
     return sv[3:,:]
+
+
+def where(condition:bool|np.ndarray, x:Number|np.ndarray, y:Number|np.ndarray)->Number|np.ndarray:
+    """
+    A wrapper around np.where to handle scalar inputs and outputs.
+
+    This function returns a scalar where that makes sense,
+    unlike np.where() which always returns an ndarray, even
+    a single-element one that it considers a scalar.
+
+    :param condition: The condition to evaluate.
+    :param x: Value to return if condition is True.
+    :param y: Value to return if condition is False.
+    :return: Scalar or array based on input types.
+    """
+    is_scalar = not isinstance(condition, np.ndarray) and not isinstance(x,np.ndarray) and not isinstance(y,np.ndarray)
+    result = np.where(condition, x, y)
+    if is_scalar and isinstance(result,np.ndarray):
+        return result.item()
+    return result
+
+
+def select(condlist:list[bool|np.ndarray], choicelist:list[Number|np.ndarray], default:Number|np.ndarray=0)->Number|np.ndarray:
+    """
+    A wrapper around np.select to handle scalar inputs and outputs.
+
+    This function returns a scalar where that makes sense,
+    unlike np.select() which always returns an ndarray, even
+    a single-element one that it considers a scalar.
+
+    :param condlist: The condition to evaluate.
+    :param x: Value to return if condition is True.
+    :param y: Value to return if condition is False.
+    :return: Scalar or array based on input types.
+    """
+    is_scalar = np.all([not isinstance(cond, np.ndarray) for cond in condlist]+
+                       [not isinstance(choice, np.ndarray) for choice in choicelist]+
+                       [not isinstance(default, np.ndarray)])
+    result = np.select(condlist, choicelist, default=default)
+    if is_scalar and isinstance(result,np.ndarray):
+        return result.item()
+    return result
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,44 @@
+"""
+Describe purpose of this script here
+
+Created: 1/23/25
+"""
+import numpy as np
+import pytest
+
+from kwanmath.vector import where, select
+
+
+@pytest.mark.parametrize(
+    "cond,a,b,out,t",
+    [(True,0,1,0,int),
+     (False,0,1,1,int),
+     (np.array((True,False)),0,1,np.array((0,1)),np.ndarray)]
+)
+def test_where(cond,a,b,out,t):
+    w=where(cond,a,b)
+    print(type(w),w)
+    assert np.all(w==out)
+    assert type(w)==t
+
+@pytest.mark.parametrize(
+    "condlist, choicelist, default, out, t",
+    [
+        # Scalar test
+        ([True], [1], 0, 1, int),
+        ([False], [1], 0, 0, int),
+        # Array test
+        ([np.array([True, False])], [np.array([1, 2])], 0, np.array([1, 0]), np.ndarray),
+        # Mixed types with scalar output
+        ([1 < 2, 2 < 3], [1, 2], 3, 1, int),
+        # Mixed types with array output
+        ([np.array([1 < 2, 2 < 3]), np.array([2 < 3, 3 < 4])],
+         [np.array([1, 2]), np.array([3, 4])],
+         5, np.array([1, 2]), np.ndarray)
+    ]
+)
+def test_select(condlist, choicelist, default, out, t):
+    s = select(condlist, choicelist, default)
+    print(type(s), s)
+    assert np.all(s == out)
+    assert type(s) == t


### PR DESCRIPTION
This pull request includes several updates to the `kwanmath` project, including a version bump, new utility functions, and corresponding tests. The most important changes are the addition of new functions in `vector.py` and their respective tests.

### Version Update:
* Updated project version from `0.1.0` to `0.2.0` in `pyproject.toml`.

### New Functions in `vector.py`:
* Added `where` function to handle scalar inputs and outputs, providing a wrapper around `np.where`.
* Added `select` function to handle scalar inputs and outputs, providing a wrapper around `np.select`.

### Testing:
* Introduced tests for the new `where` and `select` functions in `tests/test_vector.py` using `pytest`.

### Imports:
* Added `Number` import from `numbers` module in `vector.py` to facilitate type hinting for the new functions.