### PR TITLE
Add vector_to_conic() and test for same. Bump minor version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kwanmath"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
   { name="kwan3217", email="kwan3217@gmail.com" },
 ]

--- a/src/kwanmath/conic.py
+++ b/src/kwanmath/conic.py
@@ -267,6 +267,30 @@ def eval2_conic(Ap:float,Bp:float,Cp:float,Dp:float,Ep:float,scale:float=1.0)->n
     return result
 
 
+def vector_to_conic(*,cv:np.ndarray,av:np.ndarray,bv:np.ndarray,scale:float=1.0,get_points:bool=False):
+    """
+    Calculate the A-E coefficients given the center and principal axis vectors
+    :param cv: Center of ellipse
+    :param av: Vector with length equal to semimajor axis and direction of that principal axis
+    :param bv: Vector with length equal to semiminor axis and direction of that principal axis
+    :param scale: Pass along to fit_conic
+    :param get_points: If True, return the points we generate too as another element of the tuple
+    :return: A tuple:
+      Ap,Bp,Cp,Dp,Ep scaled conic coefficients
+      points: 2x5 numpy array of column vectors of 5 points on the ellipse
+    """
+    q = np.arange(5) / 5 * 2 * np.pi
+    c = np.cos(q)
+    s = np.sin(q)
+    vu = np.row_stack((c, s))
+    M = np.column_stack((av, bv))
+    ve = M @ vu + cv.reshape(-1, 1)
+    Ap, Bp, Cp, Dp, Ep = fit_conic(ve, scale=scale)
+    result=(Ap,Bp,Cp,Dp,Ep)
+    if get_points:
+        result=result+(ve,)
+    return result
+
 
 
 

--- a/tests/test_conic.py
+++ b/tests/test_conic.py
@@ -6,7 +6,7 @@ Created: 2/5/25
 import numpy as np
 import pytest
 
-from kwanmath.conic import fit_conic, eval1_conic, eval2_conic
+from kwanmath.conic import fit_conic, eval1_conic, eval2_conic, vector_to_conic
 
 test_x=np.array((603, 549, 531, 555, 601))
 test_y=np.array((230, 257, 306, 361, 380))
@@ -60,6 +60,21 @@ def test_eval2_conic(x,y,scale):
     plt.plot(x,y,'-')
     plt.axis('scaled')
     plt.pause(1)
+    assert np.allclose(A*x**2+B*x*y+C*y**2+D*x+E*y,1)
+
+
+def test_vector_to_conic():
+    """
+    Test vector_to_conic() by round trip. Make sure that cv+-av and cv+-bv satisfy conic equation
+    :return: None, but raises an exception if the test fails
+    """
+    cv=np.array([[3.0],[4.0]])
+    av=np.array([[2.0],[1.0]])
+    bv=np.array([[-1.0],[2.0]])
+    A,B,C,D,E,rr=vector_to_conic(cv=cv,av=av,bv=bv,scale=1,get_points=True)
+    r=np.hstack((cv+av,cv-av,cv+bv,cv-bv,rr))
+    x=r[0,:]
+    y=r[1,:]
     assert np.allclose(A*x**2+B*x*y+C*y**2+D*x+E*y,1)
 
 


### PR DESCRIPTION
This pull request includes updates to the `kwanmath` project, including a version bump, a new function in the `conic` module, and corresponding tests. The most important changes are summarized below:

New functionality:

* [`src/kwanmath/conic.py`](diffhunk://#diff-e74e2734fafdc349702b461124ac6ca44259cf1bd49b0bc0a84b39f47b920413R270-R293): Added a new function `vector_to_conic` that calculates the A-E coefficients given the center and principal axis vectors.

Testing:

* [`tests/test_conic.py`](diffhunk://#diff-a9c3dc84d8c5b03130ab90bbfabc167d28406187f98dd8c235f02ab008d28804R66-R80): Added a new test function `test_vector_to_conic` to ensure the `vector_to_conic` function works correctly by round trip verification.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.3.1` to `0.4.0`.
