### PR TITLE
Axis and Angle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kwanmath"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   { name="kwan3217", email="kwan3217@gmail.com" },
 ]

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 
 from kwanmath.geodesy import llr2xyz
-from kwanmath.matrix import rot_axis, euler_matrix, point_toward
-from kwanmath.vector import vcomp
+from kwanmath.matrix import rot_axis, euler_matrix, point_toward, aa_to_m, m_to_aa
+from kwanmath.vector import vcomp, vnormalize
 
 
 @pytest.mark.parametrize(
@@ -136,3 +136,9 @@ def test_point_toward(p_b:np.ndarray,p_r:np.ndarray,t_b:np.ndarray,t_r:np.ndarra
     assert np.allclose(p_r,test_Mrb @ p_b)
     assert np.allclose(p_r,ref_Mrb @ p_b)
 
+
+def test_axis_angle():
+    ref_aa=45.0*vnormalize(vcomp((1.0,1.0,1.0)))
+    M_rb=aa_to_m(ref_aa,deg=True)
+    test_aa=m_to_aa(M_rb,deg=True)
+    assert np.allclose(test_aa,ref_aa)


### PR DESCRIPTION
This adds the axis-angle encoding of an element of SO(3) (a rotation in 3D), the axis-angle. The relative orientation of any two frames can be represented as a single rotation around an axis by an angle. This code translates a relative orientation encoded by a 3x3 matrix (assumed to be a member of SO(3)) to an axis-angle representation and conversely.

Version update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.4.0` to `0.5.0`.

New functionality:
* [`src/kwanmath/matrix.py`](diffhunk://#diff-364f4995ff186d80856569bb573bb4f6a02d1f06bc0c572a5f06c1b333e11d25R247-R335): Added `m_to_aa` and `aa_to_m` functions for converting between rotation matrices and axis-angle representations.
* [`src/kwanmath/matrix.py`](diffhunk://#diff-364f4995ff186d80856569bb573bb4f6a02d1f06bc0c572a5f06c1b333e11d25L12-R12): Updated imports to include new vector operations `vcomp`, `vlength`, and `vdecomp`.

Test coverage:
* [`tests/test_matrix.py`](diffhunk://#diff-fe854f2e43a3ef13d637d45df78b58f0fbb88b59046c768cd7c81e9fa2e79347R139-R144): Added tests for the new `m_to_aa` and `aa_to_m` functions to ensure accurate conversions between matrix and axis-angle representations.
* [`tests/test_matrix.py`](diffhunk://#diff-fe854f2e43a3ef13d637d45df78b58f0fbb88b59046c768cd7c81e9fa2e79347L8-R9): Updated imports to include new functions and vector operations used in the tests