### PR TITLE
Fixed bug in m_to_aa() with small angles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kwanmath"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   { name="kwan3217", email="kwan3217@gmail.com" },
 ]

--- a/src/kwanmath/matrix.py
+++ b/src/kwanmath/matrix.py
@@ -267,7 +267,18 @@ def m_to_aa(M_rb:np.ndarray,deg:bool=False)->np.ndarray:
 
     # Case for theta = 0 (no rotation)
     if trace == 3:
-        return vcomp((0.0,0.0,0.0))  # or any vector with zero magnitude
+        # In this case, the matrix is:
+        #       [ 1 -z  y]
+        # M_rb= [ z  1 -x]
+        #       [-y  x  1]
+        # where [[x],[y],[z]] has magnitude ~sin(theta) and correct direction
+        # but the angle is so small that sin(theta)~=theta in radians. with error O(epsilon**3)
+        result=vcomp((M_rb[2, 1],
+                      M_rb[0, 2],
+                      M_rb[1, 0]))  # Use the (noninverted) off-diagonal values
+        if deg:
+            result=np.rad2deg(result)
+        return result
 
     # Angle of rotation
     theta = np.arccos((trace - 1) / 2.0)
@@ -312,7 +323,9 @@ def aa_to_m(aa_vector,deg:bool=False):
     if theta == 0:
         return np.eye(3)
 
-    # Normalize the vector to get the axis of rotation
+    # Normalize the vector to get the axis of rotation. We do this
+    # before converting theta to radians, because that's what is
+    # needed to get a unit vector.
     axis = aa_vector / theta
     if deg:
         theta=np.deg2rad(theta)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -6,7 +6,7 @@ import pytest
 
 from kwanmath.geodesy import llr2xyz
 from kwanmath.matrix import rot_axis, euler_matrix, point_toward, aa_to_m, m_to_aa
-from kwanmath.vector import vcomp, vnormalize
+from kwanmath.vector import vcomp, vnormalize, vlength
 
 
 @pytest.mark.parametrize(
@@ -142,3 +142,14 @@ def test_axis_angle():
     M_rb=aa_to_m(ref_aa,deg=True)
     test_aa=m_to_aa(M_rb,deg=True)
     assert np.allclose(test_aa,ref_aa)
+
+
+def test_small_aa():
+    ref_aa=1e-99*vnormalize(vcomp((1.0,1.0,1.0)))
+    assert vlength(ref_aa)!=0.0, "ref_aa too small, indistinguishable from 0"
+    M_rb=aa_to_m(ref_aa,deg=True)
+    trace=np.trace(M_rb)
+    assert trace==3.0, f"ref_aa not small enough to test this case, {trace.hex()}!={(3.0).hex()}"
+    test_aa=m_to_aa(M_rb,deg=True)
+    print(ref_aa,test_aa)
+    assert np.isclose(vlength(ref_aa),vlength(test_aa),atol=0)


### PR DESCRIPTION
This pull request includes updates to the `kwanmath` project, focusing on version increment, matrix transformation functions, and adding new test cases. The most important changes are summarized below:


Enhancements to matrix transformation functions:
* [`src/kwanmath/matrix.py`](diffhunk://#diff-364f4995ff186d80856569bb573bb4f6a02d1f06bc0c572a5f06c1b333e11d25L270-R281): Improved the `m_to_aa` function to handle the case where the rotation angle is near zero by providing a more accurate result.
* [`src/kwanmath/matrix.py`](diffhunk://#diff-364f4995ff186d80856569bb573bb4f6a02d1f06bc0c572a5f06c1b333e11d25L315-R328): Enhanced the `aa_to_m` function to normalize the vector before converting the angle to radians, ensuring the correct unit vector is derived.

Testing improvements:
* [`tests/test_matrix.py`](diffhunk://#diff-fe854f2e43a3ef13d637d45df78b58f0fbb88b59046c768cd7c81e9fa2e79347L9-R9): Added the `vlength` import to support new test cases.
* [`tests/test_matrix.py`](diffhunk://#diff-fe854f2e43a3ef13d637d45df78b58f0fbb88b59046c768cd7c81e9fa2e79347R145-R155): Introduced a new test case `test_small_aa` to verify the behavior of very small axis-angle vectors, ensuring they are distinguishable from zero and correctly transformed

Version update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Incremented the project version from `0.5.0` to `0.5.1`.
