### PR TITLE
Added deg= parameter to vangle()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kwanmath"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   { name="kwan3217", email="kwan3217@gmail.com" },
 ]

--- a/src/kwanmath/vector.py
+++ b/src/kwanmath/vector.py
@@ -79,13 +79,14 @@ def vnormalize(v):
     return v/vlength(v)
 
 
-def vangle(a, b, array=False):
+def vangle(a, b, array=False, deg:bool=False):
     """
     Compute the angle between two vectors
 
     :param a: (stack of) first  vector operand(s)
     :param b: (stack of) second vector operand(s)
     :param array: Passed to vdot and vlength
+    :param deg: If true, return angle in degrees. Otherwise radians by default.
     :return: Angle(s) between two (stacks of) vectors in radians
 
     Note - using true real numbers, it is impossible for the dot product to be
@@ -105,7 +106,11 @@ def vangle(a, b, array=False):
             arg=-1
         if arg> 1:
             arg= 1
-    return np.arccos(arg)
+    result=np.arccos(arg)
+    if deg:
+        result=np.rad2deg(result)
+    return result
+
 
 def vcomp(comps):
     """

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -6,7 +6,7 @@ Created: 1/23/25
 import numpy as np
 import pytest
 
-from kwanmath.vector import where, select
+from kwanmath.vector import where, select, vcomp, vangle
 
 
 @pytest.mark.parametrize(
@@ -42,3 +42,14 @@ def test_select(condlist, choicelist, default, out, t):
     print(type(s), s)
     assert np.all(s == out)
     assert type(s) == t
+
+
+@pytest.mark.parametrize(
+    "a,b,deg,result",
+    [(vcomp((1,0,0)),vcomp((0,1,0)),True,90.0),
+     (vcomp((1,0,0)),vcomp((1,1,0)),True,45.0),
+     (vcomp((1,0,0)),vcomp((1,1,0)),False,np.pi/4.0),
+     ]
+)
+def test_vangle(a:np.ndarray,b:np.ndarray,deg:bool,result:np.ndarray):
+    assert np.allclose(vangle(a,b,deg=deg),result)


### PR DESCRIPTION
### Enhancements to `vangle` Function:
* [`src/kwanmath/vector.py`](diffhunk://#diff-820fb793e2e30735ef7eb9d17662f7e564692ef9daef5e74305d972b719ef497L82-R89): Added a `deg` parameter to the `vangle` function to allow returning the angle in degrees. Updated the function to convert the result to degrees if the `deg` parameter is set to `True`. [[1]](diffhunk://#diff-820fb793e2e30735ef7eb9d17662f7e564692ef9daef5e74305d972b719ef497L82-R89) [[2]](diffhunk://#diff-820fb793e2e30735ef7eb9d17662f7e564692ef9daef5e74305d972b719ef497L108-R113)

### Tests:
* [`tests/test_vector.py`](diffhunk://#diff-9015a571b99c47cd2ead359473f847a329dcd66f0dc34b09249d7b8fc77b61ccL9-R9): Imported the `vangle` function and added new tests to verify the `deg` parameter functionality in the `vangle` function. [[1]](diffhunk://#diff-9015a571b99c47cd2ead359473f847a329dcd66f0dc34b09249d7b8fc77b61ccL9-R9) [[2]](diffhunk://#diff-9015a571b99c47cd2ead359473f847a329dcd66f0dc34b09249d7b8fc77b61ccR45-R55)

### Version Update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the package version from `0.5.1` to `0.6.0`.

